### PR TITLE
Add Connapse — knowledge backend MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [C# Openscad MCP](https://github.com/WaromiV/openscad-ai-cs) - HTTP MCP server in C# that renders OpenSCAD models into deterministic multi-view PNG images for LLM tool consumption
 - [McpServer-In-Docker](https://github.com/ravindersirohi/McpServer-In-Docker) -MCP server with Azure Function app running inside docker container, exposing two tools for LLM use.
 - [WeatherMCPDemo](https://github.com/toreaurstadboss/WeatherMCPDemo) - Weather MCP Demo Using the Model Context Protocol for AI chat based tool powered apps
+- [Connapse](https://github.com/Destrayon/Connapse) - Self-hosted knowledge backend for AI agents with hybrid vector + keyword search, container-isolated indexes, and 11 MCP tools
 
 #### Official
 - [FileSystem](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem) - Secure file operations with configurable access controls.


### PR DESCRIPTION
Adds [Connapse](https://github.com/Destrayon/Connapse) to the DotNET servers list.

Self-hosted knowledge backend for AI agents built with .NET 10. Features hybrid vector + keyword search, container-isolated knowledge bases, 11 MCP tools, and 4 storage connectors (S3, Azure Blob, MinIO, filesystem). Docker-ready with multi-arch support.

- **Transport:** Streamable HTTP
- **License:** MIT
- **Registry:** [Official MCP Registry](https://registry.modelcontextprotocol.io)