### PR TITLE
Add FlashAlpha — options analytics MCP server (ASP.NET Core)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [C# Openscad MCP](https://github.com/WaromiV/openscad-ai-cs) - HTTP MCP server in C# that renders OpenSCAD models into deterministic multi-view PNG images for LLM tool consumption
 - [McpServer-In-Docker](https://github.com/ravindersirohi/McpServer-In-Docker) -MCP server with Azure Function app running inside docker container, exposing two tools for LLM use.
 - [WeatherMCPDemo](https://github.com/toreaurstadboss/WeatherMCPDemo) - Weather MCP Demo Using the Model Context Protocol for AI chat based tool powered apps
+- [FlashAlpha](https://github.com/FlashAlpha-lab/flashalpha-mcp) - Real-time options analytics MCP server built with ASP.NET Core 8 and ModelContextProtocol.AspNetCore. 23 tools for gamma/delta/vanna/charm exposure, dealer positioning, 0DTE analytics, SVI volatility surfaces, VRP, Black-Scholes greeks, and historical tick data.
 
 #### Official
 - [FileSystem](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem) - Secure file operations with configurable access controls.


### PR DESCRIPTION
## Summary
- Adds [FlashAlpha](https://github.com/FlashAlpha-lab/flashalpha-mcp) to the DotNET servers section
- Real-time options analytics MCP server built with ASP.NET Core 8 and ModelContextProtocol.AspNetCore v1.2.0
- 23 tools covering gamma/delta/vanna/charm exposure, dealer positioning, 0DTE analytics, SVI volatility surfaces, VRP, Black-Scholes greeks, and historical tick data
- Uses Streamable HTTP transport