### PR TITLE
Add BlazeDex — Blazor/Razor MCP server for .NET 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [C# Openscad MCP](https://github.com/WaromiV/openscad-ai-cs) - HTTP MCP server in C# that renders OpenSCAD models into deterministic multi-view PNG images for LLM tool consumption
 - [McpServer-In-Docker](https://github.com/ravindersirohi/McpServer-In-Docker) -MCP server with Azure Function app running inside docker container, exposing two tools for LLM use.
 - [WeatherMCPDemo](https://github.com/toreaurstadboss/WeatherMCPDemo) - Weather MCP Demo Using the Model Context Protocol for AI chat based tool powered apps
+- [tomasfil/blazedex](https://github.com/tomasfil/blazedex) - Blazor/Razor MCP server for .NET 10. Roslyn-backed indexing resolves component usages, event handlers, and routes to exact `.razor:line:col` via the Razor source generator's `#line` directives. 20 tools across discovery, usage tracing, API introspection, quality lints (render-mode conflicts, dead routes, unused components), and one safe edit. Elastic License 2.0 (source-available).
 
 #### Official
 - [FileSystem](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem) - Secure file operations with configurable access controls.


### PR DESCRIPTION
## Adds

BlazeDex — a Blazor/Razor-aware MCP server for .NET 10. Indexes a
Blazor solution through Roslyn's `MSBuildWorkspace`, walks the Razor
source generator's `*.razor.g.cs` output, and resolves every component
usage, event-handler binding, and route back to the exact
`.razor:line:column` via the Razor `#line` directives.

## 20 tools across 6 categories

- **Discovery**: `list_razor_components`, `list_pages`, `find_component`, `find_components_injecting`, `find_route_definitions`
- **Usage**: `find_component_usages`, `find_handler_bindings`, `find_parameter_passers`, `find_binding_targets`, `find_bind_inventory`
- **API**: `get_component_api`, `get_component_tree`, `get_cascading_chain`
- **Quality**: `find_unused_components`, `find_route_conflicts`, `find_render_mode_conflicts`, `find_dead_routes`
- **Edit**: `add_parameter`
- **Diagnostics**: `ping`, `get_index_status`

## Differentiator vs existing Blazor MCP entries

BlazeDex works against **your own solution's source graph** (not
reflection over compiled assemblies, not a specific vendor library's
documentation mirror). Every answer is anchored to exact
`.razor:line:col` through the Razor `#line` mapping.

## Notes

- Built on the official C# SDK (`ModelContextProtocol` 1.2.0).
- Tier 1 in-memory index with per-call stat-based fingerprint
  revalidation + Tier 2 SQLite warm-load (18-22 ms on process restart).
- Yellow-but-never-red: broken projects serve `resolved: false` rows
  with reasons rather than throwing.
- License: Elastic License 2.0 (source-available) — free for personal
  and commercial internal use; restricted from commercial resale as
  a hosted service.
- v0.1.0 released: https://github.com/tomasfil/blazedex/releases/tag/v0.1.0