### PR TITLE
Add GameDev-MCP-Server (Servers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [C# Openscad MCP](https://github.com/WaromiV/openscad-ai-cs) - HTTP MCP server in C# that renders OpenSCAD models into deterministic multi-view PNG images for LLM tool consumption
 - [McpServer-In-Docker](https://github.com/ravindersirohi/McpServer-In-Docker) -MCP server with Azure Function app running inside docker container, exposing two tools for LLM use.
 - [WeatherMCPDemo](https://github.com/toreaurstadboss/WeatherMCPDemo) - Weather MCP Demo Using the Model Context Protocol for AI chat based tool powered apps
-- [GameDev-MCP-Server](https://github.com/IvanMurzak/GameDev-MCP-Server) - Open-source, engine-agnostic MCP server shared by Unity-MCP, Godot-MCP, and Unreal-MCP, exposing game-engine editor and runtime tools to AI agents.
+- [GameDev-MCP-Server](https://github.com/IvanMurzak/GameDev-MCP-Server) - Engine-agnostic MCP server exposing game-engine editor and runtime tools to AI agents, connecting Unity, Godot, and Unreal; the Unity-MCP/Godot-MCP/Unreal-MCP engine plugins built on it are open-source (Apache-2.0, public repos).
 
 #### Official
 - [FileSystem](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem) - Secure file operations with configurable access controls.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [C# Openscad MCP](https://github.com/WaromiV/openscad-ai-cs) - HTTP MCP server in C# that renders OpenSCAD models into deterministic multi-view PNG images for LLM tool consumption
 - [McpServer-In-Docker](https://github.com/ravindersirohi/McpServer-In-Docker) -MCP server with Azure Function app running inside docker container, exposing two tools for LLM use.
 - [WeatherMCPDemo](https://github.com/toreaurstadboss/WeatherMCPDemo) - Weather MCP Demo Using the Model Context Protocol for AI chat based tool powered apps
+- [GameDev-MCP-Server](https://github.com/IvanMurzak/GameDev-MCP-Server) - Open-source, engine-agnostic MCP server shared by Unity-MCP, Godot-MCP, and Unreal-MCP, exposing game-engine editor and runtime tools to AI agents.
 
 #### Official
 - [FileSystem](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem) - Secure file operations with configurable access controls.


### PR DESCRIPTION
Adds one open-source (Apache-2.0) .NET/MCP project: GameDev-MCP-Server (Servers) is an engine-agnostic MCP server exposing game-engine editor and runtime tools to AI agents, shared by our Unity-MCP, Godot-MCP, and Unreal-MCP game-engine plugins. Maintained at github.com/IvanMurzak/GameDev-MCP-Server.

Note: I initially also intended to add MCP-Plugin-dotnet under SDKs, but noticed it's already listed in this README under Servers > DotNET (built on top of it, and shares the same underlying library). To avoid a duplicate listing of the same repo, I left that entry as-is for now — happy to open a follow-up PR to move/update it if you'd prefer it categorized under SDKs instead.

Happy to adjust formatting/placement to match this list's conventions — thanks for maintaining it!